### PR TITLE
Return value's type from hook callback does not match the hooked method

### DIFF
--- a/app/src/main/java/just/trust/me/pro/hook/ConscryptHook.kt
+++ b/app/src/main/java/just/trust/me/pro/hook/ConscryptHook.kt
@@ -27,7 +27,11 @@ class ConscryptHook : BaseHook() {
                 String::class.java,
                 object : XC_MethodReplacement() {
                     override fun replaceHookedMethod(param: MethodHookParam): Any? {
-                        return ArrayList<X509Certificate>()
+                        return if ((param.method as? java.lang.reflect.Method)?.returnType == Void.TYPE) {
+                            null
+                        } else {
+                            ArrayList<X509Certificate>()
+                        }
                     }
                 }
             )
@@ -43,7 +47,11 @@ class ConscryptHook : BaseHook() {
                 String::class.java,
                 object : XC_MethodReplacement() {
                     override fun replaceHookedMethod(param: MethodHookParam): Any? {
-                        return ArrayList<X509Certificate>()
+                        return if ((param.method as? java.lang.reflect.Method)?.returnType == Void.TYPE) {
+                            null
+                        } else {
+                            ArrayList<X509Certificate>()
+                        }
                     }
                 }
             )
@@ -59,7 +67,11 @@ class ConscryptHook : BaseHook() {
                 javax.net.ssl.SSLSession::class.java,
                 object : XC_MethodReplacement() {
                     override fun replaceHookedMethod(param: MethodHookParam): Any? {
-                        return ArrayList<X509Certificate>()
+                        return if ((param.method as? java.lang.reflect.Method)?.returnType == Void.TYPE) {
+                            null
+                        } else {
+                            ArrayList<X509Certificate>()
+                        }
                     }
                 }
             )
@@ -77,8 +89,12 @@ class ConscryptHook : BaseHook() {
                 javax.net.ssl.SSLParameters::class.java,
                 Boolean::class.javaPrimitiveType,
                 object : XC_MethodReplacement() {
-                    override fun replaceHookedMethod(param: MethodHookParam): Any {
-                        return ArrayList<X509Certificate>()
+                    override fun replaceHookedMethod(param: MethodHookParam): Any? {
+                        return if ((param.method as? java.lang.reflect.Method)?.returnType == Void.TYPE) {
+                            null
+                        } else {
+                            ArrayList<X509Certificate>()
+                        }
                     }
                 }
             )
@@ -96,8 +112,12 @@ class ConscryptHook : BaseHook() {
                 String::class.java,
                 Boolean::class.javaPrimitiveType,
                 object : XC_MethodReplacement() {
-                    override fun replaceHookedMethod(param: MethodHookParam): Any {
-                        return ArrayList<X509Certificate>()
+                    override fun replaceHookedMethod(param: MethodHookParam): Any? {
+                        return if ((param.method as? java.lang.reflect.Method)?.returnType == Void.TYPE) {
+                            null
+                        } else {
+                            ArrayList<X509Certificate>()
+                        }
                     }
                 }
             )

--- a/app/src/main/java/just/trust/me/pro/hook/OkHttpHook.kt
+++ b/app/src/main/java/just/trust/me/pro/hook/OkHttpHook.kt
@@ -29,7 +29,7 @@ class OkHttpHook : BaseHook() {
                 List::class.java,
                 object : XC_MethodHook() {
                     override fun beforeHookedMethod(param: MethodHookParam) {
-                        param.result = Unit
+                        param.result = null
                     }
                 }
             )


### PR DESCRIPTION
crash:

```
java.lang.ClassCastException: Return value's type from hook callback does not match the hooked method
 at org.lsposed.lspd.impl.LSPosedBridge$NativeHooker.callback(r8-map-id-bd8a188c72dcb420b3bf2c8bb5c3bcde85b40b6a76b9f502e6132e524d661836:310)
 at LSPHooker_.checkServerTrusted(Unknown Source:17)
 at okhttp3.internal.platform.android.AndroidCertificateChainCleaner.clean(Unknown Source:25)
 at okhttp3.internal.connection.RealConnection$connectTls$1.invoke(SourceFile:4)
 at okhttp3.internal.connection.RealConnection$connectTls$1.invoke(SourceFile:1)
 at okhttp3.Handshake$peerCertificates$2.invoke(SourceFile:2)
 at okhttp3.Handshake$peerCertificates$2.invoke(SourceFile:1)
 at dn.q.getValue(Unknown Source:20)
 at okhttp3.Handshake.peerCertificates(Unknown Source:2)
 at okhttp3.Cache$Entry.writeTo(Unknown Source:241)
 at okhttp3.Cache.put$okhttp(Unknown Source:86)
 at okhttp3.internal.cache.CacheInterceptor.intercept(Unknown Source:361)
 at okhttp3.internal.http.RealInterceptorChain.proceed(Unknown Source:151)
 at okhttp3.internal.http.BridgeInterceptor.intercept(Unknown Source:169)
 at okhttp3.internal.http.RealInterceptorChain.proceed(Unknown Source:151)
 at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(Unknown Source:34)
 ```